### PR TITLE
Modified to inherit Incisive from Xcelium

### DIFF
--- a/vunit/sim_if/incisive.py
+++ b/vunit/sim_if/incisive.py
@@ -8,60 +8,35 @@
 Interface for the Cadence Incisive simulator
 """
 
-from pathlib import Path
-from os.path import relpath
-import os
-import subprocess
-import logging
-from ..exceptions import CompileError
-from ..ostools import write_file, file_exists
 from ..vhdl_standard import VHDL
-from . import SimulatorInterface, run_command, ListOfStringOption
-from .cds_file import CDSFile
-
-LOGGER = logging.getLogger(__name__)
+from . import ListOfStringOption
+from .xcelium import XceliumInterface
 
 
-class IncisiveInterface(  # pylint: disable=too-many-instance-attributes
-    SimulatorInterface
-):
+class IncisiveInterface(XceliumInterface):
     """
     Interface for the Cadence Incisive simulator
     """
 
     name = "incisive"
-    supports_gui_flag = True
-    package_users_depend_on_bodies = False
+    executable_name = "irun"
+    option_prefix = "nc"
 
     compile_options = [
         ListOfStringOption("incisive.irun_vhdl_flags"),
         ListOfStringOption("incisive.irun_verilog_flags"),
     ]
 
-    sim_options = [ListOfStringOption("incisive.irun_sim_flags")]
+    sim_options = [
+        ListOfStringOption("incisive.irun_sim_flags")
+    ]
 
-    # NOTE: Incisive shares the command-line arguments with Xcelium
-
-    @classmethod
-    def from_args(cls, args, output_path, **kwargs):
+    @staticmethod
+    def add_arguments(parser):
         """
-        Create new instance from command line arguments object
+        Add command line arguments
         """
-        return cls(
-            prefix=cls.find_prefix(),
-            output_path=output_path,
-            log_level=args.log_level,
-            gui=args.gui,
-            cdslib=args.cdslib,
-            hdlvar=args.hdlvar,
-        )
-
-    @classmethod
-    def find_prefix_from_path(cls):
-        """
-        Find incisive simulator from PATH environment variable
-        """
-        return cls.find_toolchain(["irun"])
+        # NOTE: Incisive shares the command-line arguments with Xcelium
 
     @staticmethod
     def supports_vhdl_contexts():
@@ -70,96 +45,10 @@ class IncisiveInterface(  # pylint: disable=too-many-instance-attributes
         """
         return False
 
-    def __init__(  # pylint: disable=too-many-arguments
-        self, prefix, output_path, gui=False, log_level=None, cdslib=None, hdlvar=None
-    ):
-        SimulatorInterface.__init__(self, output_path, gui)
-        self._prefix = prefix
-        self._libraries = []
-        self._log_level = log_level
-        if cdslib is None:
-            self._cdslib = str((Path(output_path) / "cds.lib").resolve())
-        else:
-            self._cdslib = str(Path(cdslib).resolve())
-        self._hdlvar = hdlvar
-        self._cds_root_irun = self.find_cds_root_irun()
-        self._create_cdslib()
-
-    def find_cds_root_irun(self):
-        """
-        Finds irun cds root
-        """
-        return subprocess.check_output(
-            [str(Path(self._prefix) / "cds_root"), "irun"]
-        ).splitlines()[0]
-
-    def find_cds_root_virtuoso(self):
-        """
-        Finds virtuoso cds root
-        """
-        try:
-            return subprocess.check_output(
-                [str(Path(self._prefix) / "cds_root"), "virtuoso"]
-            ).splitlines()[0]
-        except subprocess.CalledProcessError:
-            return None
-
-    def _create_cdslib(self):
-        """
-        Create the cds.lib file in the output directory if it does not exist
-        """
-        cds_root_virtuoso = self.find_cds_root_virtuoso()
-
-        if cds_root_virtuoso is None:
-            contents = """\
-## cds.lib: Defines the locations of compiled libraries.
-softinclude {0}/tools/inca/files/cds.lib
-# needed for referencing the library 'basic' for cells 'cds_alias', 'cds_thru' etc. in analog models:
-# NOTE: 'virtuoso' executable not found!
-# define basic ".../tools/dfII/etc/cdslib/basic"
-define work "{1}/libraries/work"
-""".format(
-                self._cds_root_irun, self._output_path
-            )
-        else:
-            contents = """\
-## cds.lib: Defines the locations of compiled libraries.
-softinclude {0}/tools/inca/files/cds.lib
-# needed for referencing the library 'basic' for cells 'cds_alias', 'cds_thru' etc. in analog models:
-define basic "{1}/tools/dfII/etc/cdslib/basic"
-define work "{2}/libraries/work"
-""".format(
-                self._cds_root_irun, cds_root_virtuoso, self._output_path
-            )
-
-        write_file(self._cdslib, contents)
-
-    def setup_library_mapping(self, project):
-        """
-        Compile project using vhdl_standard
-        """
-        mapped_libraries = self._get_mapped_libraries()
-
-        for library in project.get_libraries():
-            self._libraries.append(library)
-            self.create_library(library.name, library.directory, mapped_libraries)
-
-    def compile_source_file_command(self, source_file):
-        """
-        Returns the command to compile a single source file
-        """
-        if source_file.is_vhdl:
-            return self.compile_vhdl_file_command(source_file)
-
-        if source_file.is_any_verilog:
-            return self.compile_verilog_file_command(source_file)
-
-        raise CompileError
-
     @staticmethod
     def _vhdl_std_opt(vhdl_standard):
         """
-        Convert standard to format of irun command line flag
+        Convert standard to format of xrun command line flag
         """
         if vhdl_standard == VHDL.STD_2002:
             return "-v200x -extv200x"
@@ -171,232 +60,3 @@ define work "{2}/libraries/work"
             return "-v93"
 
         raise ValueError("Invalid VHDL standard %s" % vhdl_standard)
-
-    def compile_vhdl_file_command(self, source_file):
-        """
-        Returns command to compile a VHDL file
-        """
-        cmd = str(Path(self._prefix) / "irun")
-        args = []
-        args += ["-compile"]
-        args += ["-nocopyright"]
-        args += ["-licqueue"]
-        args += ["-nowarn DLCPTH"]  # "cds.lib Invalid path"
-        args += ["-nowarn DLCVAR"]  # "cds.lib Invalid environment variable ''."
-        args += ["%s" % self._vhdl_std_opt(source_file.get_vhdl_standard())]
-        args += ["-work work"]
-        args += ['-cdslib "%s"' % self._cdslib]
-        args += self._hdlvar_args()
-        args += [
-            '-log "%s"'
-            % str(
-                Path(self._output_path)
-                / ("irun_compile_vhdl_file_%s.log" % source_file.library.name)
-            )
-        ]
-        if not self._log_level == "debug":
-            args += ["-quiet"]
-        else:
-            args += ["-messages"]
-            args += ["-libverbose"]
-        args += source_file.compile_options.get("incisive.irun_vhdl_flags", [])
-        args += ['-nclibdirname "%s"' % str(Path(source_file.library.directory).parent)]
-        args += ["-makelib %s" % source_file.library.directory]
-        args += ['"%s"' % source_file.name]
-        args += ["-endlib"]
-        argsfile = str(
-            Path(self._output_path)
-            / ("irun_compile_vhdl_file_%s.args" % source_file.library.name)
-        )
-        write_file(argsfile, "\n".join(args))
-        return [cmd, "-f", argsfile]
-
-    def compile_verilog_file_command(self, source_file):
-        """
-        Returns commands to compile a Verilog file
-        """
-        cmd = str(Path(self._prefix) / "irun")
-        args = []
-        args += ["-compile"]
-        args += ["-nocopyright"]
-        args += ["-licqueue"]
-        # "Ignored unexpected semicolon following SystemVerilog description keyword (endfunction)."
-        args += ["-nowarn UEXPSC"]
-        # "cds.lib Invalid path"
-        args += ["-nowarn DLCPTH"]
-        # "cds.lib Invalid environment variable ''."
-        args += ["-nowarn DLCVAR"]
-        args += ["-work work"]
-        args += source_file.compile_options.get("incisive.irun_verilog_flags", [])
-        args += ['-cdslib "%s"' % self._cdslib]
-        args += self._hdlvar_args()
-        args += [
-            '-log "%s"'
-            % str(
-                Path(self._output_path)
-                / ("irun_compile_verilog_file_%s.log" % source_file.library.name)
-            )
-        ]
-        if not self._log_level == "debug":
-            args += ["-quiet"]
-        else:
-            args += ["-messages"]
-            args += ["-libverbose"]
-        for include_dir in source_file.include_dirs:
-            args += ['-incdir "%s"' % include_dir]
-
-        # for "disciplines.vams" etc.
-        args += ['-incdir "%s/tools/spectre/etc/ahdl/"' % self._cds_root_irun]
-
-        for key, value in source_file.defines.items():
-            args += ["-define %s=%s" % (key, value.replace('"', '\\"'))]
-        args += ['-nclibdirname "%s"' % str(Path(source_file.library.directory).parent)]
-        args += ["-makelib %s" % source_file.library.name]
-        args += ['"%s"' % source_file.name]
-        args += ["-endlib"]
-        argsfile = str(
-            Path(self._output_path)
-            / ("irun_compile_verilog_file_%s.args" % source_file.library.name)
-        )
-        write_file(argsfile, "\n".join(args))
-        return [cmd, "-f", argsfile]
-
-    def create_library(self, library_name, library_path, mapped_libraries=None):
-        """
-        Create and map a library_name to library_path
-        """
-        mapped_libraries = mapped_libraries if mapped_libraries is not None else {}
-
-        lpath = str(Path(library_path).resolve().parent)
-
-        if not file_exists(lpath):
-            os.makedirs(lpath)
-
-        if (
-            library_name in mapped_libraries
-            and mapped_libraries[library_name] == library_path
-        ):
-            return
-
-        cds = CDSFile.parse(self._cdslib)
-        cds[library_name] = library_path
-        cds.write(self._cdslib)
-
-    def _get_mapped_libraries(self):
-        """
-        Get mapped libraries from cds.lib file
-        """
-        cds = CDSFile.parse(self._cdslib)
-        return cds
-
-    def simulate(  # pylint: disable=too-many-locals
-        self, output_path, test_suite_name, config, elaborate_only=False
-    ):
-        """
-        Elaborates and Simulates with entity as top level using generics
-        """
-
-        script_path = str(Path(output_path) / self.name)
-        launch_gui = self._gui is not False and not elaborate_only
-
-        if elaborate_only:
-            steps = ["elaborate"]
-        else:
-            steps = ["elaborate", "simulate"]
-
-        for step in steps:
-            cmd = str(Path(self._prefix) / "irun")
-            args = []
-            if step == "elaborate":
-                args += ["-elaborate"]
-            args += ["-nocopyright"]
-            args += ["-licqueue"]
-            # args += ['-dumpstack']
-            # args += ['-gdbsh']
-            # args += ['-rebuild']
-            # args += ['-gdb']
-            # args += ['-gdbelab']
-            args += ["-errormax 10"]
-            args += ["-nowarn WRMNZD"]
-            args += ["-nowarn DLCPTH"]  # "cds.lib Invalid path"
-            args += ["-nowarn DLCVAR"]  # "cds.lib Invalid environment variable ''."
-            args += [
-                "-ncerror EVBBOL"
-            ]  # promote to error: "bad boolean literal in generic association"
-            args += [
-                "-ncerror EVBSTR"
-            ]  # promote to error: "bad string literal in generic association"
-            args += [
-                "-ncerror EVBNAT"
-            ]  # promote to error: "bad natural literal in generic association"
-            args += ["-work work"]
-            args += [
-                '-nclibdirname "%s"' % (str(Path(self._output_path) / "libraries"))
-            ]  # @TODO: ugly
-            args += config.sim_options.get("incisive.irun_sim_flags", [])
-            args += ['-cdslib "%s"' % self._cdslib]
-            args += self._hdlvar_args()
-            args += ['-log "%s"' % str(Path(script_path) / ("irun_%s.log" % step))]
-            if not self._log_level == "debug":
-                args += ["-quiet"]
-            else:
-                args += ["-messages"]
-                # args += ['-libverbose']
-            args += self._generic_args(config.entity_name, config.generics)
-            for library in self._libraries:
-                args += ['-reflib "%s"' % library.directory]
-            if launch_gui:
-                args += ["-access +rwc"]
-                # args += ['-linedebug']
-                args += ["-gui"]
-            else:
-                args += ["-access +r"]
-                args += ['-input "@run"']
-
-            if config.architecture_name is None:
-                # we have a SystemVerilog toplevel:
-                args += ["-top %s.%s:sv" % (config.library_name, config.entity_name)]
-            else:
-                # we have a VHDL toplevel:
-                args += [
-                    "-top %s.%s:%s"
-                    % (
-                        config.library_name,
-                        config.entity_name,
-                        config.architecture_name,
-                    )
-                ]
-            argsfile = "%s/irun_%s.args" % (script_path, step)
-            write_file(argsfile, "\n".join(args))
-            if not run_command(
-                [cmd, "-f", relpath(argsfile, script_path)],
-                cwd=script_path,
-                env=self.get_env(),
-            ):
-                return False
-        return True
-
-    def _hdlvar_args(self):
-        """
-        Return hdlvar argument if available
-        """
-        if self._hdlvar is None:
-            return []
-        return ['-hdlvar "%s"' % self._hdlvar]
-
-    @staticmethod
-    def _generic_args(entity_name, generics):
-        """
-        Create irun arguments for generics/parameters
-        """
-        args = []
-        for name, value in generics.items():
-            if _generic_needs_quoting(value):
-                args += ['''-gpg "%s.%s => \\"%s\\""''' % (entity_name, name, value)]
-            else:
-                args += ['''-gpg "%s.%s => %s"''' % (entity_name, name, value)]
-        return args
-
-
-def _generic_needs_quoting(value):  # pylint: disable=missing-docstring
-    return isinstance(value, (str, bool))


### PR DESCRIPTION
@umarcor I need help here

I tried to inherit Incisive from Xcelium. It was relatively simple, but I am not sure about how to solve a lot of pytests issues.

Before changes, the following was ok:
```
pytest tests/lint/
pytest tests/unit/
```

After changes, there are a lot of issues, where maybe you can help (after all, you suggested this change :smiley:)

With `pytest tests/lint/` there are a lot of
```
tests/lint/test_pylint.py:16: in <module>
    from tests.lint.test_pycodestyle import get_files_and_folders
<frozen importlib._bootstrap>:991: in _find_and_load
    ???
<frozen importlib._bootstrap>:975: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:671: in _load_unlocked
    ???
/usr/local/lib/python3.8/dist-packages/_pytest/assertion/rewrite.py:170: in exec_module
    exec(co, module.__dict__)
tests/lint/test_pycodestyle.py:16: in <module>
    from vunit import ROOT as RSTR
vunit/__init__.py:13: in <module>
    from vunit.ui import VUnit
vunit/ui/__init__.py:24: in <module>
    from ..vunit_cli import VUnitCLI
vunit/vunit_cli.py:40: in <module>
    from vunit.sim_if.factory import SIMULATOR_FACTORY
vunit/sim_if/factory.py:175: in <module>
    SIMULATOR_FACTORY = SimulatorFactory()
vunit/sim_if/factory.py:157: in __init__
    self._compile_options = self._extract_compile_options()
vunit/sim_if/factory.py:49: in _extract_compile_options
    assert opt.name.startswith(sim_class.name + ".")
E   AssertionError
```

With `pytest tests/unit/` there a lot of
```
tests/unit/test_xcelium_interface.py:20: in <module>
    from vunit.project import Project
vunit/__init__.py:13: in <module>
    from vunit.ui import VUnit
vunit/ui/__init__.py:24: in <module>
    from ..vunit_cli import VUnitCLI
vunit/vunit_cli.py:40: in <module>
    from vunit.sim_if.factory import SIMULATOR_FACTORY
vunit/sim_if/factory.py:175: in <module>
    SIMULATOR_FACTORY = SimulatorFactory()
vunit/sim_if/factory.py:157: in __init__
    self._compile_options = self._extract_compile_options()
vunit/sim_if/factory.py:49: in _extract_compile_options
    assert opt.name.startswith(sim_class.name + ".")
E   AssertionError
```

As you can see, in both cases related to `assert opt.name.startswith(sim_class.name + ".")`

